### PR TITLE
Start on SkillTree classes

### DIFF
--- a/src/main/java/com/teamvitalis/vitalis/skilltree/ISkillTreeObject.java
+++ b/src/main/java/com/teamvitalis/vitalis/skilltree/ISkillTreeObject.java
@@ -1,0 +1,19 @@
+package com.teamvitalis.vitalis.skilltree;
+
+import org.bukkit.inventory.ItemStack;
+
+import com.teamvitalis.vitalis.api.CoreAbility;
+
+public interface ISkillTreeObject {
+	
+	public String getDisplayName();
+	
+	public ItemStack getDisplayIcon();
+	
+	public ISkillTreeObject[] getParents();
+	
+	public CoreAbility[] getAbilities();
+	
+	public int getID();
+	
+}

--- a/src/main/java/com/teamvitalis/vitalis/skilltree/SkillTreeBuilder.java
+++ b/src/main/java/com/teamvitalis/vitalis/skilltree/SkillTreeBuilder.java
@@ -1,0 +1,124 @@
+package com.teamvitalis.vitalis.skilltree;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.bukkit.entity.HumanEntity;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+
+import com.teamvitalis.vitalis.Vitalis;
+import com.teamvitalis.vitalis.api.CoreAbility;
+import com.teamvitalis.vitalis.object.Lang;
+import com.teamvitalis.vitalis.object.VitalisPlayer;
+
+public class SkillTreeBuilder {
+
+	private Vitalis plugin;
+
+	private Lang name;
+	private ItemStack icon;
+	private int id;
+	private final List<ISkillTreeObject> parents = new ArrayList<>();
+	private final List<CoreAbility> abilities = new ArrayList<>();
+	private SkillTreeClickListener stcl;
+
+	public SkillTreeBuilder(Vitalis plugin) {
+		this.plugin = plugin;
+	}
+
+	public void clear() {
+		name = null;
+		icon = null;
+		id = -1;
+		parents.clear();
+		abilities.clear();
+		stcl = null;
+	}
+	
+	public SkillTreeObject buildAndClear() {
+		SkillTreeObject skill = build();
+		clear();
+		return skill;
+	}
+	
+	public SkillTreeObject build() {
+
+		SkillTreeBuilder builder = this;
+		SkillTreeObject skill = new SkillTreeObject(plugin) {
+
+			public SkillTreeObject init() {
+				this.name = builder.name;
+				this.icon = builder.icon;
+				this.id = builder.id;
+				this.parents.clear();
+				this.parents.addAll(builder.parents);
+				this.abilities.clear();
+				this.abilities.addAll(builder.abilities);
+				this.stcl = builder.stcl;
+				return this;
+			}
+
+			@Override
+			public void clicked(InventoryClickEvent event) {
+				ItemStack item = event.getCurrentItem();
+				if (!item.isSimilar(icon))
+					return;
+				HumanEntity whoClicked = event.getWhoClicked();
+				if (!(whoClicked instanceof Player))
+					return;
+				VitalisPlayer vp = VitalisPlayer.fromPlayer((Player) whoClicked);
+				if (vp == null)
+					return;
+				Inventory inv = event.getInventory();
+				this.stcl.click(vp, inv);
+			}
+
+		}.init();
+		return skill;
+	}
+
+	public void setSkillTreeClickListener(SkillTreeClickListener stcl) {
+		this.stcl = stcl;
+	}
+
+	public Lang getName() {
+		return name;
+	}
+
+	public void setName(Lang name) {
+		this.name = name;
+	}
+
+	public ItemStack getIcon() {
+		return icon;
+	}
+
+	public void setIcon(ItemStack icon) {
+		this.icon = icon;
+	}
+
+	public int getId() {
+		return id;
+	}
+
+	public void setId(int id) {
+		this.id = id;
+	}
+
+	public List<ISkillTreeObject> getParents() {
+		return parents;
+	}
+
+	public List<CoreAbility> getAbilities() {
+		return abilities;
+	}
+
+	public interface SkillTreeClickListener extends Listener {
+		public void click(VitalisPlayer player, Inventory inv);
+	}
+
+}

--- a/src/main/java/com/teamvitalis/vitalis/skilltree/SkillTreeObject.java
+++ b/src/main/java/com/teamvitalis/vitalis/skilltree/SkillTreeObject.java
@@ -1,0 +1,78 @@
+package com.teamvitalis.vitalis.skilltree;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.inventory.ItemStack;
+
+import com.teamvitalis.vitalis.Vitalis;
+import com.teamvitalis.vitalis.api.CoreAbility;
+import com.teamvitalis.vitalis.object.Lang;
+import com.teamvitalis.vitalis.skilltree.SkillTreeBuilder.SkillTreeClickListener;
+
+public abstract class SkillTreeObject implements ISkillTreeObject, Listener {
+
+	private static final List<SkillTreeObject> INSTANCES = new ArrayList<>();
+
+	protected Lang name;
+	protected ItemStack icon;
+	protected int id;
+	protected final List<ISkillTreeObject> parents = new ArrayList<>();
+	protected final List<CoreAbility> abilities = new ArrayList<>();
+	protected SkillTreeClickListener stcl;
+	
+	/**
+	 * <h1><b>DO NOT CALL THIS CONSTRUCTOR MANUALLY!!</b></h1>
+	 */
+	public SkillTreeObject(Vitalis plugin) {
+		plugin.getServer().getPluginManager().registerEvents(this, plugin);
+	}
+	
+	@Override
+	public String getDisplayName() {
+		return name.toString();
+	}
+
+	@Override
+	public ItemStack getDisplayIcon() {
+		return icon;
+	}
+
+	@Override
+	public ISkillTreeObject[] getParents() {
+		return parents.toArray(new ISkillTreeObject[parents.size()]);
+	}
+
+	public void addParent(ISkillTreeObject isto) {
+		parents.add(isto);
+	}
+	
+	public void removeParent(ISkillTreeObject isto) {
+		parents.remove(isto);
+	}
+	
+	@Override
+	public CoreAbility[] getAbilities() {
+		return abilities.toArray(new CoreAbility[abilities.size()]);
+	}
+
+	@Override
+	public int getID() {
+		return id;
+	}
+	
+	public static SkillTreeObject register(SkillTreeObject sto) {
+		int id = sto.getID();
+		if (INSTANCES.stream().filter(s -> s.getID() == id).count() != 0)
+			return INSTANCES.get(id);
+		INSTANCES.add(sto);
+		return sto;
+	}
+	
+	@EventHandler
+	public abstract void clicked(InventoryClickEvent event);
+	
+}


### PR DESCRIPTION
Note; This is just a base and many things are still subject to change or
removal, new features will be added as well.

Added the ISkillTreeObject interface, which just contains some essential
methods.

Added the SkillTreeObject (abstract) class, which contains important
information about the SkillTreeObject, as well as getters and setters
for these fields. It's constructor should not be called manually.

Added the SkillTreeBuilder class, which allows developers to create new
SkillTreeObjects without creating a whole new class and extending
SkillTreeObject. To create a new SkillTreeObject, either create a new
instance of SkillTreeBuilder or call the 'clean' method on an already
existing instance, then start setting some fields using the setters, and
finally call the 'build' method to get the SkillTreeObject.