### PR TITLE
Passive Ability Handling, Sample Lunamancy Abilities "Longevity, Empowerment, SilverShield", Soft Dependency Support, Misc Fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,8 +13,12 @@
       <id>spigot-repo</id>
       <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
     </repository>
+    <repository>
+      <id>inventive-repo</id>
+      <url>https://repo.inventivetalent.org/content/groups/public/</url>
+    </repository>
   </repositories>
-  
+
   <dependencies>
     <!--Spigot API-->
     <dependency>
@@ -41,6 +45,11 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
       <version>1.7.21</version>
+    </dependency>
+    <dependency>
+      <groupId>org.inventivetalent</groupId>
+      <artifactId>glowapi</artifactId>
+      <version>1.4.4</version>
     </dependency>
   </dependencies>
   

--- a/src/main/java/com/teamvitalis/vitalis/Vitalis.java
+++ b/src/main/java/com/teamvitalis/vitalis/Vitalis.java
@@ -1,5 +1,7 @@
 package com.teamvitalis.vitalis;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.logging.Logger;
 
 import com.teamvitalis.vitalis.casts.GlobalPassives;
@@ -23,6 +25,7 @@ public class Vitalis extends JavaPlugin {
 	private static Vitalis plugin;
 	private static Logger log;
 	private static Database database;
+	private static List<String> hooks;
 
 	@Override
 	public void onEnable() {
@@ -32,7 +35,15 @@ public class Vitalis extends JavaPlugin {
 		Database.initiateFile();
 		database = new Database();
 		new DBMethods(database).configureDatabase();
-		
+
+		hooks = new ArrayList<>();
+		for (String name : new String[] {"GlowAPI", "PacketListenerApi"}) { // Add Optional Hooks here
+			if (getServer().getPluginManager().isPluginEnabled(name)) {
+				logger().info("Found plugin hook \"" + name + "\"!");
+				hooks.add(name);
+			}
+		}
+
 		for (Player player : Bukkit.getOnlinePlayers()) {
 			VitalisPlayer.load(player);
 		}
@@ -67,4 +78,6 @@ public class Vitalis extends JavaPlugin {
 	public static Logger logger() {
 		return log;
 	}
+
+	public static boolean hasHook(String name) { return hooks.contains(name); }
 }

--- a/src/main/java/com/teamvitalis/vitalis/Vitalis.java
+++ b/src/main/java/com/teamvitalis/vitalis/Vitalis.java
@@ -2,6 +2,7 @@ package com.teamvitalis.vitalis;
 
 import java.util.logging.Logger;
 
+import com.teamvitalis.vitalis.casts.GlobalPassives;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.java.JavaPlugin;
@@ -22,7 +23,7 @@ public class Vitalis extends JavaPlugin {
 	private static Vitalis plugin;
 	private static Logger log;
 	private static Database database;
-	
+
 	@Override
 	public void onEnable() {
 		plugin = this;
@@ -43,6 +44,8 @@ public class Vitalis extends JavaPlugin {
 		new Commands(this).loadCommands();
 		BaseCast.loadAll();
 		new CollisionHandler();
+
+		GlobalPassives.start();
 	}
 	
 	@Override

--- a/src/main/java/com/teamvitalis/vitalis/casts/GlobalPassives.java
+++ b/src/main/java/com/teamvitalis/vitalis/casts/GlobalPassives.java
@@ -1,0 +1,18 @@
+package com.teamvitalis.vitalis.casts;
+
+import com.teamvitalis.vitalis.Vitalis;
+import com.teamvitalis.vitalis.casts.luna.LunaPassives;
+
+/**
+ * Created by Kagami95 "Carbogen" on 04/08/2016.
+ */
+public class GlobalPassives {
+	public static void start() {
+		Vitalis.plugin().getServer().getScheduler().scheduleSyncRepeatingTask(Vitalis.plugin(), new Runnable() {
+			@Override
+			public void run() {
+				LunaPassives.runAll();
+			}
+		}, 0, 1L);
+	}
+}

--- a/src/main/java/com/teamvitalis/vitalis/casts/luna/Empowerment.java
+++ b/src/main/java/com/teamvitalis/vitalis/casts/luna/Empowerment.java
@@ -1,0 +1,37 @@
+package com.teamvitalis.vitalis.casts.luna;
+
+import com.teamvitalis.vitalis.Vitalis;
+import net.md_5.bungee.api.ChatColor;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.potion.PotionEffect;
+import org.bukkit.potion.PotionEffectType;
+
+/**
+ * Created by Kagami95 "Carbogen" on 04/08/2016.
+ */
+public class Empowerment {
+	public static PotionEffectType[] effects = new PotionEffectType[] {
+		PotionEffectType.DAMAGE_RESISTANCE, PotionEffectType.INCREASE_DAMAGE, PotionEffectType.SPEED, PotionEffectType.JUMP
+	};
+
+	public static int getEffect(Player p) {
+		int phase = LunaMethods.getLunarPhase(p.getWorld());
+
+		int effect = (--phase < 1) ? 0 : phase;
+		return effect;
+	}
+
+	public static void apply(Player p) {
+		for (PotionEffectType type : effects)
+			p.addPotionEffect(new PotionEffect(type, 30, getEffect(p)), true);
+	}
+
+	public static void run() {
+		for (Player p : Bukkit.getOnlinePlayers()) {
+			if (LunaMethods.isLunamancer(p) && LunaMethods.getLunarPhase(p.getWorld()) > 1) {
+				apply(p);
+			}
+		}
+	}
+}

--- a/src/main/java/com/teamvitalis/vitalis/casts/luna/Longevity.java
+++ b/src/main/java/com/teamvitalis/vitalis/casts/luna/Longevity.java
@@ -1,0 +1,27 @@
+package com.teamvitalis.vitalis.casts.luna;
+
+import net.md_5.bungee.api.ChatColor;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+
+/**
+ * Created by Kagami95 "Carbogen" on 04/08/2016.
+ */
+public class Longevity {
+	public static int getEffect(Player p) {
+		int phase = LunaMethods.getLunarPhase(p.getWorld());
+		return (6 - (6 - phase * 2)) * 2;
+	}
+
+	public static void run() {
+		for (Player p : Bukkit.getOnlinePlayers()) {
+			if (LunaMethods.isLunamancer(p)) {
+				int effect = getEffect(p);
+				if (p.getMaxHealth() != (20 + effect)) {
+					p.setMaxHealth(20 + effect);
+					p.sendMessage(ChatColor.GRAY + "A change in moonlight has changed your health buffer to " + p.getMaxHealth());
+				}
+			}
+		}
+	}
+}

--- a/src/main/java/com/teamvitalis/vitalis/casts/luna/LunaMethods.java
+++ b/src/main/java/com/teamvitalis/vitalis/casts/luna/LunaMethods.java
@@ -20,7 +20,7 @@ public class LunaMethods {
 	 *  0: New Moon
 	 */
 	public static int getLunarPhase(World world) {
-		long days = world.getFullTime()/24000 - ((world.getFullTime()%24000 < 12500) ? 1 : 0);
+		long days = world.getFullTime()/24000 - ((world.getTime() < 12500) ? 1 : 0);
 		int phase = (int) Math.abs(4-(days%8));
 		return phase;
 	}

--- a/src/main/java/com/teamvitalis/vitalis/casts/luna/LunaMethods.java
+++ b/src/main/java/com/teamvitalis/vitalis/casts/luna/LunaMethods.java
@@ -1,0 +1,39 @@
+package com.teamvitalis.vitalis.casts.luna;
+
+import com.teamvitalis.vitalis.object.ClassType;
+import com.teamvitalis.vitalis.object.MagicType;
+import com.teamvitalis.vitalis.object.Mancer;
+import com.teamvitalis.vitalis.object.VitalisPlayer;
+import org.bukkit.World;
+import org.bukkit.entity.Player;
+
+/**
+ * Created by Kagami95 "Carbogen" on 04/08/2016.
+ */
+public class LunaMethods {
+
+	/* Returns:
+	 *  4: Full Moon
+	 *  3: Gibbous Moon
+	 *  2: Quarter Moon
+	 *  1: Crescent Moon
+	 *  0: New Moon
+	 */
+	public static int getLunarPhase(World world) {
+		long days = world.getFullTime()/24000 - ((world.getFullTime()%24000 < 12500) ? 1 : 0);
+		int phase = (int) Math.abs(4-(days%8));
+		return phase;
+	}
+
+	public static boolean isLunamancer(Player p) {
+		VitalisPlayer vp = VitalisPlayer.fromPlayer(p);
+		if (vp != null && vp.getClassType() == ClassType.MANCER) {
+			Mancer mvp = (Mancer) vp; // "...Most Valuable Player?" LOL
+			if (mvp.getMagicType() == MagicType.LUNA) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+}

--- a/src/main/java/com/teamvitalis/vitalis/casts/luna/LunaPassives.java
+++ b/src/main/java/com/teamvitalis/vitalis/casts/luna/LunaPassives.java
@@ -6,5 +6,7 @@ package com.teamvitalis.vitalis.casts.luna;
 public class LunaPassives {
 	public static void runAll() {
 		Longevity.run();
+		Empowerment.run();
+		SilverShield.run();
 	}
 }

--- a/src/main/java/com/teamvitalis/vitalis/casts/luna/LunaPassives.java
+++ b/src/main/java/com/teamvitalis/vitalis/casts/luna/LunaPassives.java
@@ -1,0 +1,10 @@
+package com.teamvitalis.vitalis.casts.luna;
+
+/**
+ * Created by Kagami95 "Carbogen" on 04/08/2016.
+ */
+public class LunaPassives {
+	public static void runAll() {
+		Longevity.run();
+	}
+}

--- a/src/main/java/com/teamvitalis/vitalis/casts/luna/SilverShield.java
+++ b/src/main/java/com/teamvitalis/vitalis/casts/luna/SilverShield.java
@@ -1,0 +1,57 @@
+package com.teamvitalis.vitalis.casts.luna;
+
+import com.teamvitalis.vitalis.Vitalis;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.Sound;
+import org.bukkit.entity.Arrow;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Player;
+import org.bukkit.util.Vector;
+import org.inventivetalent.glow.GlowAPI;
+
+/**
+ * Created by Kagami95 "Carbogen" on 04/08/2016.
+ */
+public class SilverShield {
+
+	public static void deflect(Player p) {
+		for (Entity en : p.getWorld().getEntities()) {
+			if (en instanceof Arrow) {
+				Arrow arrow = (Arrow) en;
+				Location loc = arrow.getLocation();
+				Vector v = arrow.getVelocity();
+				for (float i = 1; i < 4.; i += 0.5) {
+					double d = loc.add(v.normalize().multiply(i)).distance(p.getLocation());
+					if (d < 2.5) {
+						if (arrow.getLocation().distance(p.getLocation()) > 4.0 || arrow.isOnGround() || arrow.getShooter() == p)
+							continue;
+						arrow.setShooter(p);
+						arrow.setVelocity(v.multiply(-1.0).normalize().multiply(1.4));
+						p.getWorld().playSound(loc, Sound.ENTITY_ITEM_BREAK, 1, 1);
+						if (Vitalis.hasHook("GlowAPI")) {
+							Vitalis.plugin().getServer().getScheduler().runTaskAsynchronously(Vitalis.plugin(), new Runnable() {
+								@Override
+								public void run() {
+									GlowAPI.setGlowing(p, GlowAPI.Color.WHITE, Bukkit.getOnlinePlayers());
+									long time = System.currentTimeMillis();
+									while (System.currentTimeMillis() < time + 250) {
+									}
+									GlowAPI.setGlowing(p, false, Bukkit.getOnlinePlayers());
+								}
+							});
+						}
+					}
+				}
+			}
+		}
+	}
+
+	public static void run() {
+		for (Player p : Bukkit.getOnlinePlayers()) {
+			if (LunaMethods.isLunamancer(p) && LunaMethods.getLunarPhase(p.getWorld()) == 4) {
+				deflect(p);
+			}
+		}
+	}
+}

--- a/src/main/java/com/teamvitalis/vitalis/commands/ACommand.java
+++ b/src/main/java/com/teamvitalis/vitalis/commands/ACommand.java
@@ -47,6 +47,14 @@ public abstract class ACommand implements ICommand {
 	public String getProperUse() {
 		return properUse;
 	}
+
+	public String getTemplate() {
+		String template = "";
+		for (String word : getProperUse().split(" "))
+			if (word.charAt(0) != '[' && word.charAt(0) != '<')
+				template += word + " ";
+		return template;
+	}
 	
 	public String[] getAliases() {
 		return aliases;

--- a/src/main/java/com/teamvitalis/vitalis/commands/HelpCommand.java
+++ b/src/main/java/com/teamvitalis/vitalis/commands/HelpCommand.java
@@ -38,7 +38,7 @@ public class HelpCommand extends ACommand{
 				TextComponent tc = new TextComponent(ChatColor.GRAY + command.getProperUse());
 				String tooltip = WordUtils.wrap(ChatColor.GRAY + command.getHelp(), 40, "\n" + ChatColor.GRAY, false);
 				tc.setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, new ComponentBuilder(tooltip).create()));
-				tc.setClickEvent(new ClickEvent(ClickEvent.Action.SUGGEST_COMMAND, command.getProperUse()));
+				tc.setClickEvent(new ClickEvent(ClickEvent.Action.SUGGEST_COMMAND, command.getTemplate()));
 				order.add(command.getName());
 				components.put(command.getName(), tc);
 			}

--- a/src/main/java/com/teamvitalis/vitalis/listeners/PlayerListener.java
+++ b/src/main/java/com/teamvitalis/vitalis/listeners/PlayerListener.java
@@ -9,7 +9,7 @@ import org.bukkit.Statistic;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
-import org.bukkit.event.player.PlayerLoginEvent;
+import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerMoveEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
 
@@ -33,7 +33,7 @@ public class PlayerListener implements Listener{
 	}
 	
 	@EventHandler
-	public void onLogin(PlayerLoginEvent event) {
+	public void onJoin(PlayerJoinEvent event) {
 		Player player = event.getPlayer();
 		JUMPS.put(player, player.getStatistic(Statistic.JUMP));
 		VitalisPlayer.load(player);

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -2,6 +2,7 @@ name: Vitalis
 main: com.teamvitalis.vitalis.Vitalis
 version: ${project.version}
 author: vitalis
+softdepend: ["PacketListenerApi","GlowAPI"]
 
 commands:
     vitalis:


### PR DESCRIPTION
[08-04-2016]
- Modified HelpCommand.java's click event so command parameters are not included. This avoids the need to backspace them out in-game. This was done by adding the method `ACommand.getTemplate()`.

- Replaced `PlayerListener.onLogin(PlayerLoginEvent event)` with `PlayerListener.onJoin(PlayerJoinEvent event)`. `org.bukkit.event.player.PlayerLoginEvent` fires before a player joins the game, even if they are banned/using a wrong game version. This can cause some unwanted behavior. `org.bukkit.event.player.PlayerJoinEvent`, on the other hand, fires when a player successfully joins the server.

- Added a Passive for Lunamancers: Longevity. Also included are a class for handling Passives (GlobalPassives.java), and a class providing Lunamancy-related methods: LunaMethods.

[08-05-2016]
- Added more abilities for Lunamancers, though none are final. This gives us some things to play around with while developing the framework for handling/managing abilities, and the skill tree.

- Added a soft dependency to GlowAPI (lets us color "Spectral" auras) to `resources/plugin.yml`. `Luna/SilverShield.java` has a usage example on lines 36 and 40.

- Added a `boolean hasHook(String)` method to Vitalis.java for checking whether or not soft dependencies are present on the server.

- Updated pom.xml to include GlowAPI as a library